### PR TITLE
add a Prolog-like %! ... !% multiline comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ LOGIC-PREDS: creatureo ;
     { cato Y } ;; { mouseo Y }
 } rule
 ```
-`;;` is used to represent **disjunction**. The code below it has the same meaning as the code below it.
+`;;` is used to represent **disjunction**. The following two forms are equivalent:
 ```
 Gh { Gb1 Gb2 Gb3 ;; Gb4 Gb5 ;; Gb6 } rule
 ```

--- a/factlog/factlog-docs.factor
+++ b/factlog/factlog-docs.factor
@@ -1,7 +1,7 @@
 ! Copyright (C) 2019-2020 KUSUMOTO Norio.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: arrays help.markup help.syntax kernel quotations sequences
-    prettyprint assocs math lists urls factlog.private ;
+    prettyprint assocs math make lists urls factlog.private ;
 IN: factlog
 
 HELP: !!
@@ -138,6 +138,18 @@ HELP: LOGIC-VARS:
     "{ mouseo X } query ."
     "{ H{ { X Jerry } } }"
   }
+} ;
+
+HELP: %!
+{ $description "A multiline comment. Despite being a Prolog single-line comment, " { $link % } " is already well-known in Factor, so this variant is given instead." }
+{ $syntax "%! comment !%" }
+{ $examples
+    { $example
+        "USE: factlog"
+        "%! I think that I shall never see"
+        "   A proof lovely as a factlog. !%"
+        ""
+    }
 } ;
 
 HELP: \+
@@ -722,7 +734,7 @@ SYMBOLS: Tom Jerry Nibbles ;"
     { cato Y } ;; { mouseo Y }
 } rule"
 } $nl
-{ $link ;; } " is used to represent " { $strong "disjunction" } ". The code below it has the same meaning as the code below it." $nl
+{ $link ;; } " is used to represent " { $strong "disjunction" } ". The following two forms are equivalent:" $nl
 { $code "Gh { Gb1 Gb2 Gb3 ;; Gb4 Gb5 ;; Gb6 } rule" }
 $nl
 { $code

--- a/factlog/factlog.factor
+++ b/factlog/factlog.factor
@@ -2,8 +2,8 @@
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors arrays assocs classes classes.tuple combinators
 combinators.short-circuit compiler.units continuations
-formatting fry io kernel lexer lists locals make math namespaces
-parser prettyprint prettyprint.backend prettyprint.config
+formatting fry io kernel lexer lists locals make math multiline
+namespaces parser prettyprint prettyprint.backend prettyprint.config
 prettyprint.custom prettyprint.sections quotations sequences
 sequences.deep sets splitting strings words words.symbol
 vectors ;
@@ -58,6 +58,9 @@ SYNTAX: LOGIC-PREDS: ";"
         [ [ name>> <pred> ] keep set-global ] tri
     ] each-token ;
 >>
+
+SYNTAX: %!
+  "!%" parse-multiline-string drop ;
 
 <PRIVATE
 
@@ -573,4 +576,3 @@ LOGIC-PREDS:
 
 { listo L{ } } fact
 { listo L{ __ . __ } } fact
-


### PR DESCRIPTION
- just for fun, the last thing missing is the
	ability to write Prolog-like comments in
	factlog. it uses the multiline vocab, and
	is implemented like `/* ... */`. I thought
	about making it %* ... *% instead, but
	decided to incorporate Factor's comment
	style.

- also, a small change to README.md and the
	"How to use factlog" article; a tiny
	clarification of a sentence about
	code snippets, only because it awkwardly repeated "code below it". (I will revert it if you liked the previous phrasing.)